### PR TITLE
Fix footer copyright vertical centering

### DIFF
--- a/themes/imagilux/static/css/style.css
+++ b/themes/imagilux/static/css/style.css
@@ -192,12 +192,17 @@ footer.container {
     background: var(--color-background-light);
     border-top: 1px solid var(--color-border);
     height: var(--footer-height);
+    display: flex;
     align-items: center;
-    justify-content: center;
-    text-align: center;
+    justify-content: flex-end;
+    text-align: right;
     color: var(--color-text-muted);
-    margin-top: auto;
     flex-shrink: 0;
+    padding-right: var(--spacing-md);
+}
+
+footer.container p {
+    margin: 0;
 }
 
 /* Homepage Styles */


### PR DESCRIPTION
Fixes #3

**Changes:**
- Modified footer CSS to use flexbox with  for right alignment
- Added  and  for proper vertical centering  
- Removed  and added  to clear paragraph margins
- Added  for proper spacing from edge

**Result:**
Footer copyright paragraph is now vertically centered and positioned on the right side of the footer.