### PR TITLE
Fix post layout with navigation header and styling

### DIFF
--- a/themes/imagilux/layouts/_default/single.html
+++ b/themes/imagilux/layouts/_default/single.html
@@ -1,10 +1,21 @@
-<!doctype html>
-<html>
-    <head>
-        <title>{{ .Title }}</title>
-    </head>
-    <body>
-        <h1>{{ .Title }}</h1>
-        <p>{{ .Content }}</p>
-    </body>
-</html>
+{{ define "main" }}
+<article class="post-content">
+  <header class="post-header">
+    <h1 class="post-title">{{ .Title }}</h1>
+    {{ if .Params.date }}
+    <div class="post-meta">
+      <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">
+        {{ .Date.Format "January 2, 2006" }}
+      </time>
+      {{ if .Params.author }}
+      <span class="card-author">{{ .Params.author }}</span>
+      {{ end }}
+    </div>
+    {{ end }}
+  </header>
+  
+  <div class="post-body">
+    {{ .Content }}
+  </div>
+</article>
+{{ end }}

--- a/themes/imagilux/static/css/style.css
+++ b/themes/imagilux/static/css/style.css
@@ -349,6 +349,139 @@ footer.container p {
     text-decoration: underline;
 }
 
+/* Post Content Styles */
+.post-content {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: var(--spacing-xl) var(--spacing-md) var(--spacing-xl);
+    margin-top: calc(var(--header-height) + var(--spacing-lg));
+}
+
+.post-header {
+    margin-bottom: var(--spacing-xl);
+    text-align: center;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: var(--spacing-lg);
+}
+
+.post-title {
+    font-size: var(--font-size-h1);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text);
+    margin-bottom: var(--spacing-sm);
+    line-height: 1.2;
+}
+
+.post-meta {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-small);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: var(--spacing-xs);
+    margin-top: var(--spacing-sm);
+}
+
+.post-body {
+    font-family: var(--font-family);
+    line-height: var(--line-height);
+    color: var(--color-text);
+}
+
+.post-body h1,
+.post-body h2,
+.post-body h3,
+.post-body h4,
+.post-body h5,
+.post-body h6 {
+    color: var(--color-text);
+    font-weight: var(--font-weight-semibold);
+    margin-top: var(--spacing-lg);
+    margin-bottom: var(--spacing-sm);
+}
+
+.post-body h1 {
+    font-size: var(--font-size-h1);
+    border-bottom: 2px solid var(--color-border);
+    padding-bottom: var(--spacing-xs);
+}
+
+.post-body h2 {
+    font-size: var(--font-size-h2);
+    margin-top: var(--spacing-xl);
+}
+
+.post-body h3 {
+    font-size: var(--font-size-h3);
+}
+
+.post-body p {
+    margin-bottom: var(--spacing-md);
+    color: var(--color-text-light);
+}
+
+.post-body a {
+    color: var(--color-primary);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: all var(--transition-fast);
+}
+
+.post-body a:hover {
+    color: var(--color-text);
+    border-bottom-color: var(--color-primary);
+}
+
+.post-body blockquote {
+    border-left: 4px solid var(--color-primary);
+    padding-left: var(--spacing-md);
+    margin: var(--spacing-md) 0;
+    font-style: italic;
+    color: var(--color-text-muted);
+}
+
+.post-body code {
+    background: var(--color-background-light);
+    color: var(--color-text);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.9em;
+    font-family: "Monaco", "Menlo", "Ubuntu Mono", monospace;
+}
+
+.post-body pre {
+    background: var(--color-background-light);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: var(--spacing-md);
+    overflow-x: auto;
+    margin: var(--spacing-md) 0;
+}
+
+.post-body pre code {
+    background: none;
+    padding: 0;
+}
+
+.post-body ul,
+.post-body ol {
+    margin: var(--spacing-md) 0;
+    padding-left: var(--spacing-lg);
+}
+
+.post-body li {
+    margin-bottom: var(--spacing-xs);
+    color: var(--color-text-light);
+}
+
+.post-body img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 8px;
+    margin: var(--spacing-md) 0;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     .container {
@@ -403,5 +536,28 @@ footer.container p {
 
     .articles-container {
         padding: 0 var(--spacing-sm);
+    }
+
+    /* Post content responsive */
+    .post-content {
+        margin-top: calc(var(--floating-header-height) + var(--spacing-md));
+        padding: var(--spacing-md) var(--container-padding-mobile);
+    }
+
+    .post-title {
+        font-size: var(--font-size-h2);
+    }
+
+    .post-body h1 {
+        font-size: var(--font-size-h2);
+    }
+
+    .post-body h2 {
+        font-size: var(--font-size-h3);
+    }
+
+    .post-meta {
+        flex-direction: column;
+        gap: var(--spacing-xs);
     }
 }


### PR DESCRIPTION
Fixes #5

This PR updates the single post layout to properly display the navigation header and respect the site's fonts and color scheme.

**Changes Made:**
- Updated  template to use the  layout structure
- Added comprehensive CSS styling for post content including:
  - Proper typography using site's font variables
  - Consistent color scheme
  - Responsive design for mobile devices
  - Styled headers, links, code blocks, and images
- Post layout now includes navigation header from base template
- Added post metadata display (date and author)

**Testing:**
- ✅ Hugo build successful 
- ✅ Hugo server running at http://localhost:1313
- ✅ Posts now display navigation header
- ✅ Consistent styling with rest of site