### PR TITLE
Add floating back-to-top button for long pages

### DIFF
--- a/themes/imagilux/layouts/_default/baseof.html
+++ b/themes/imagilux/layouts/_default/baseof.html
@@ -36,5 +36,6 @@
     <footer class="container">
         {{ partial "footer.html" . }}
     </footer>
+    <script src="{{ "js/back-to-top.js" | relURL }}"></script>
   </body>
 </html>

--- a/themes/imagilux/static/css/style.css
+++ b/themes/imagilux/static/css/style.css
@@ -561,3 +561,56 @@ footer.container p {
         gap: var(--spacing-xs);
     }
 }
+
+/* Back to Top Button */
+.back-to-top {
+    position: fixed;
+    bottom: 32px;
+    right: 32px;
+    width: 64px;
+    height: 64px;
+    background: var(--color-primary);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    font-weight: bold;
+    z-index: 1000;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(20px);
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 16px rgba(0, 123, 255, 0.3);
+    user-select: none;
+}
+
+.back-to-top:hover {
+    background: var(--color-text);
+    transform: translateY(0) scale(1.05);
+    box-shadow: 0 6px 24px rgba(0, 123, 255, 0.4);
+}
+
+.back-to-top.visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+.back-to-top:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+    .back-to-top {
+        bottom: 20px;
+        right: 20px;
+        width: 56px;
+        height: 56px;
+        font-size: 20px;
+    }
+}

--- a/themes/imagilux/static/js/back-to-top.js
+++ b/themes/imagilux/static/js/back-to-top.js
@@ -1,0 +1,47 @@
+// Back to Top Button Functionality
+document.addEventListener('DOMContentLoaded', function() {
+    // Create back-to-top button
+    const backToTopButton = document.createElement('button');
+    backToTopButton.className = 'back-to-top';
+    backToTopButton.innerHTML = '↑';
+    backToTopButton.setAttribute('aria-label', 'Back to top');
+    backToTopButton.setAttribute('title', 'Back to top');
+
+    // Add button to body
+    document.body.appendChild(backToTopButton);
+
+    // Show/hide button based on scroll position
+    function toggleButtonVisibility() {
+        const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+        const threshold = 300; // Show button after scrolling 300px
+
+        if (scrollTop > threshold) {
+            backToTopButton.classList.add('visible');
+        } else {
+            backToTopButton.classList.remove('visible');
+        }
+    }
+
+    // Smooth scroll to top
+    function scrollToTop() {
+        window.scrollTo({
+            top: 0,
+            behavior: 'smooth'
+        });
+    }
+
+    // Event listeners
+    window.addEventListener('scroll', toggleButtonVisibility);
+    backToTopButton.addEventListener('click', scrollToTop);
+
+    // Keyboard support
+    backToTopButton.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            scrollToTop();
+        }
+    });
+
+    // Initial check
+    toggleButtonVisibility();
+});


### PR DESCRIPTION
Closes #7

## 🎯 What
Adds a 64x64px floating back-to-top button that appears on long content pages to improve user navigation.

## ✨ Features
- Fixed position button (bottom-right corner)
- Smooth scroll-to-top functionality
- Only appears after scrolling 300px down
- Responsive design (56x56px on mobile)
- Keyboard accessibility (Enter/Space)
- Hover effects with scaling and shadows
- Matches site design system

## 🧪 Testing
- [x] Button appears/hides based on scroll position
- [x] Smooth scroll animation works
- [x] Responsive behavior on mobile
- [x] Keyboard navigation functional
- [x] Hugo build successful
- [x] Local server testing completed

## 📁 Files Changed
-  - Button styling
-  - Functionality
-  - Integration