### PR TITLE
fix #11: remove underline from nav hover

### DIFF
--- a/themes/imagilux/static/css/style.css
+++ b/themes/imagilux/static/css/style.css
@@ -122,6 +122,7 @@ header nav a:hover,
 header nav a.active {
     color: var(--color-primary);
     background: rgba(0, 123, 255, 0.1);
+    text-decoration: none;
 }
 
 /* Main Content */


### PR DESCRIPTION
Fixes #11

Removes the underline from navigation menu items when hovered by adding `text-decoration: none` to the CSS hover selector.

This maintains the existing blue color and background highlight effects while providing a cleaner visual experience.