### PR TITLE
Add subtle footer shadow for elevation effect

### DIFF
--- a/themes/imagilux/static/css/style.css
+++ b/themes/imagilux/static/css/style.css
@@ -252,6 +252,7 @@ footer.container {
     color: var(--color-text-muted);
     flex-shrink: 0;
     padding-right: var(--spacing-md);
+    box-shadow: inset 0 6px 12px -4px rgba(0, 0, 0, 0.15);
 }
 
 footer.container p {


### PR DESCRIPTION
Fixes #19

This PR adds a subtle upper inner shadow to the footer element to create a visual elevation sensation between the main body content and the footer.

**Changes:**
- Added  to the footer CSS
- Creates a discrete but visible elevation effect
- Tested with Hugo build and local server

The shadow is positioned at the top of the footer with appropriate blur and opacity for a clean, modern look.