### PR TITLE
Add language icon to header navigation

### DIFF
--- a/themes/imagilux/layouts/_default/baseof.html
+++ b/themes/imagilux/layouts/_default/baseof.html
@@ -20,6 +20,7 @@
       <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
     {{ end }}
     <link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
     {{ block "head" . }}{{ end }}
   </head>
   <body>

--- a/themes/imagilux/layouts/partials/header.html
+++ b/themes/imagilux/layouts/partials/header.html
@@ -27,6 +27,9 @@
           >{{ $name }}</a>
         </li>
       {{- end }}
+      <li>
+        <i class="fa-solid fa-language" title="Language"></i>
+      </li>
     </ul>
   </nav>
 {{- end }}

--- a/themes/imagilux/static/css/style.css
+++ b/themes/imagilux/static/css/style.css
@@ -103,12 +103,39 @@ header.container {
     justify-content: flex-start;
 }
 
+header nav {
+    width: 100%;
+}
+
 header nav ul {
     list-style: none;
     display: flex;
-    gap: var(--spacing-md);
+    align-items: center;
     margin: 0;
     position: relative;
+    width: 100%;
+}
+
+/* Add spacing between regular menu items */
+header nav ul li:not(:last-child) {
+    margin-right: var(--spacing-md);
+}
+
+/* Push the last li element to the right */
+header nav ul li:last-child {
+    margin-left: auto;
+}
+
+/* Language icon styling */
+header nav ul li:last-child i {
+    font-size: 1.2em;
+    cursor: pointer;
+    color: var(--color-text);
+    transition: color var(--transition-nav);
+}
+
+header nav ul li:last-child i:hover {
+    color: var(--color-primary);
 }
 
 /* Sliding background indicator */


### PR DESCRIPTION
Closes #21

**Changes:**
- Added Font Awesome 7.0.0 support to base template
- Added fa-language icon to the right side of header navigation
- Updated CSS to properly position the icon using flexbox
- Icon includes hover effects matching existing navigation styling

**Testing:**
- Tested locally with Hugo server
- Icon displays correctly and is properly positioned on the right side
- Maintains responsive design and accessibility