### PR TITLE
Center navigation items using flexbox

### DIFF
--- a/themes/imagilux/static/css/style.css
+++ b/themes/imagilux/static/css/style.css
@@ -119,6 +119,9 @@ header nav ul {
 
 header nav li {
     width: var(--nav-item-width);
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 /* Add spacing between regular menu items */


### PR DESCRIPTION
Fixes #25 - Added flexbox properties to horizontally and vertically center anchor elements within li containers